### PR TITLE
feat: activityコンポーネントを追加

### DIFF
--- a/src/pages/_components/Activities.astro
+++ b/src/pages/_components/Activities.astro
@@ -5,35 +5,24 @@ import ActivityCard from "./ActivityCard.astro";
 <section>
   <h2 class="my-2 text-3xl font-bold">活動内容</h2>
   <ActivityCard
-    id="about-programming"
     title="プログラミング"
     description="プログラムでアイデアを形にしよう。"
-    examples="ゲーム制作、競技プログラミング、Web開発など"
-    bgColorClass="bg-sky-50"
-    textColorClass="text-blue-600"
-    focusRingColorClass="focus-visible:ring-blue-600"
-    href="/"
+    activityExamplesText="ゲーム制作、競技プログラミング、Web開発など"
+    class="bg-sky-100 text-blue-600"
   />
   <ActivityCard
-    id="about-dtm"
     title="DTM"
-    description="あなたの音楽で感動を届けよう。\n発表会でみんなに共有しよう。"
-    examples="作曲など"
-    bgColorClass="bg-purple-50"
-    textColorClass="text-indigo-400"
-    focusRingColorClass="focus-visible:ring-indigo-400"
-    href="/"
+    description={"あなたの音楽で感動を届けよう。\n発表会でみんなに共有しよう。"}
+    activityExamplesText="作曲など"
+    class="bg-purple-100 text-violet-500"
   />
   <ActivityCard
-    id="about-graphic"
     title="グラフィック"
     description="デザインでアイデアを表現しよう。"
-    examples="イラスト、3DCGなど"
-    bgColorClass="bg-rose-50"
-    textColorClass="text-fuchsia-500"
-    focusRingColorClass="focus-visible:ring-fuchsia-500"
-    href="/"
+    activityExamplesText="イラスト、3DCGなど"
+    class="bg-pink-100 text-fuchsia-500"
   />
+
   <div class="my-2">
     <p>各メンバーが多種多様な創作活動を行っています。</p>
     <p>これ以外にも、あなたが興味を持った活動ができます！</p>
@@ -41,7 +30,7 @@ import ActivityCard from "./ActivityCard.astro";
 
   <a
     href="/"
-    class="my-2 inline-flex rounded-full bg-fuchsia-500 px-6 py-3 shadow-md/50 transition-transform duration-100 hover:-translate-y-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-500 focus-visible:ring-offset-2 active:translate-y-0.5"
+    class="my-2 inline-flex rounded-full bg-pink-600/90 px-6 py-3 shadow-md/50 transition-transform duration-100 hover:-translate-y-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-pink-600/90 focus-visible:ring-offset-2 active:translate-y-0.5"
   >
     <span class="text-base font-bold text-white">活動内容をもっと見る <span aria-hidden="true">&rarr;</span></span>
   </a>

--- a/src/pages/_components/ActivityCard.astro
+++ b/src/pages/_components/ActivityCard.astro
@@ -1,31 +1,21 @@
 ---
 interface Props {
-  id?: string;
   title: string;
   description: string;
-  examples: string;
-  bgColorClass: string;
-  textColorClass: string;
-  focusRingColorClass: string;
-  href: string;
+  activityExamplesText: string;
+  class?: string;
 }
 
-const { id, title, description, examples, bgColorClass, textColorClass, focusRingColorClass, href } = Astro.props;
+const { title, description, activityExamplesText, class: className } = Astro.props;
 ---
 
-<a
-  href={href}
-  id={id}
-  class=`
-	block
-	px-4 py-2 my-5
-	${bgColorClass}
-	rounded-3xl shadow-lg/25
-	focus:outline-none
-	focus-visible:ring-2 ${focusRingColorClass} focus-visible:ring-offset-2
-	`
+<div
+  class:list={[
+    "my-5 rounded-3xl px-4 py-2 shadow-lg/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+    className,
+  ]}
 >
-  <h3 class=`text-2xl md:text-3xl font-bold ${textColorClass} my-2`>{title}</h3>
-  <p class="my-2 text-xs whitespace-pre">{description}</p>
-  <p class="my-2 text-base font-bold">{examples}</p>
-</a>
+  <h3 class=`text-2xl md:text-3xl font-bold my-2`>{title}</h3>
+  <p class="my-2 text-xs whitespace-pre-line text-black">{description}</p>
+  <p class="my-2 text-base font-bold text-black">{activityExamplesText}</p>
+</div>


### PR DESCRIPTION
## 概要
* Activitiesコンポーネントを追加
* `Activities.astro`内部で使う`ActivityCard.astro`を追加
* 分野ごとのパネルについて、画面幅768px以上（`md`）でフォントサイズが`text-2xl`から`text-3xl`になるよう設定

## 関連 Issue
- Close #6 

## スクリーンショット
| figma | 実装 |
| :----: | :----: |
|![ccs_hp_figma](https://github.com/user-attachments/assets/c2d91256-6aae-4c86-a496-a10439d029a7)|![ccs_hp_astro](https://github.com/user-attachments/assets/a9dcc4de-6a7e-4e91-ab1b-7505e14029a0)|

## 備考
* 分野ごとのパネルについて、`a`タグでリンク化してあります。パネルはリンクじゃなくて良い場合は`div`などに置き換えます。
* 現時点でリンクは全て`/`です。利用時は正しいリンクに置き換えてください。
* 最下部のボタンについて、`Join.astro`からの使い回しです。
* ActivityCard.astroについて分野ごとに使い回そうとしたため`props`がかなり量があります。3分野だけで分ける必要ない場合は`Activities.astro`に直書きします。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 活動セクションを構造化し、カード形式で複数の活動（プログラミング、DTM、グラフィック）を表示
  * 各カードにタイトル、説明、具体例を明確に表示して視認性を向上
  * セクション見出しと説明テキストを追加し、内容の導線を強化
  * 「もっと見る」リンクを追加して詳細へのアクセスを改善
<!-- end of auto-generated comment: release notes by coderabbit.ai -->