### PR TITLE
style(header): improve header spacing and clickable title alignment

### DIFF
--- a/src/components/Header/index.astro
+++ b/src/components/Header/index.astro
@@ -8,12 +8,12 @@ import circleLogo from "../../assets/circle-logo.png";
 ---
 
 <header class="sticky top-0 z-10 border-b border-zinc-200 bg-white">
-  <div class="flex h-12 items-center justify-between pr-3">
-    <div class="flex h-full min-w-0 items-stretch gap-3">
-      <a href="/" aria-label="ホームへ移動" class="inline-flex h-full shrink-0 items-stretch">
+  <div class="flex h-14 items-center justify-between gap-4 px-4 md:justify-start">
+    <div class="flex h-full min-w-0 items-stretch gap-3 py-2">
+      <a href="/" aria-label="ホームへ移動" class="inline-flex h-full shrink-0 items-stretch gap-2">
         <Image src={circleLogo} alt="" densities={[1, 2]} class="block h-full w-auto" />
+        <span class="flex min-w-0 items-center truncate text-base font-medium text-zinc-800">{HEADER_TITLE}</span>
       </a>
-      <span class="flex min-w-0 items-center truncate text-base font-medium text-zinc-800">{HEADER_TITLE}</span>
     </div>
 
     <div class="flex h-full shrink-0 items-center">


### PR DESCRIPTION
## 概要

<!-- この PR での変更点などを記載してください -->

ヘッダーの調整
- "CCS" もクリック可能に
- 通常のナビゲーションは左寄りに

## 関連 Issue

<!--
関連する issue があれば記載してください

例: - Close #123
`Close` の前にハイフンとスペースを入れることで issue が見やすくなります
-->

N/A

## スクリーンショット

<!--
見た目の変更がある場合にはスクリーンショットを添付してください

変更がない場合はこのセクションを削除して構いません
-->

| 変更前 | 変更後 |
| :----: | :----: |
|<img width="1690" height="52" alt="image" src="https://github.com/user-attachments/assets/67c262f3-9098-499a-b4ad-865656c25b29" />|<img width="1690" height="60" alt="image" src="https://github.com/user-attachments/assets/32021719-8ea5-40d5-a836-3ea07b5deff5" />|

## 備考

<!--
その他伝えておきたいことがあれば記載してください

- 補足事項
- 注意点
- レビューで特に見てほしい箇所
など
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ヘッダーの高さ、パディング、要素間のギャップを調整しました
  * ロゴとタイトルの配置を改善し、より視認性の高いレイアウトを実現しました
  * 大画面でのヘッダー表示のアライメント動作を微調整しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->