### PR TITLE
feat: newsページ作成

### DIFF
--- a/src/pages/_components/News.astro
+++ b/src/pages/_components/News.astro
@@ -6,7 +6,7 @@ interface Props {
   showAllButton?: boolean;
 }
 
-const { description, showAllButton = "true" } = Astro.props;
+const { description, showAllButton = true } = Astro.props;
 ---
 
 <section>
@@ -14,7 +14,7 @@ const { description, showAllButton = "true" } = Astro.props;
   {description && <p class="mt-2 mb-4">{description}</p>}
   <slot />
   {
-    showAllButton === "true" && (
+    showAllButton && (
       <Button class="mt-6 bg-purple-600 text-white shadow-purple-600/50 focus-visible:ring-purple-600" href="/news">
         すべてのNewsを見る<span aria-hidden="true">&rarr;</span>
       </Button>

--- a/src/pages/news.astro
+++ b/src/pages/news.astro
@@ -6,7 +6,7 @@ import Layout from "../layouts/Layout.astro";
 
 <Layout title="News">
   <div class="mx-5 my-4 flex flex-col gap-8 md:mx-auto md:w-4/5 xl:w-2/3 2xl:w-1/2">
-    <News description="CCSからのお知らせです。" showAllButton="false">
+    <News description="CCSからのお知らせです。" showAllButton={false}>
       <!-- TODO: insert me -->
       <NewsContent
         href="link/to/news/page"


### PR DESCRIPTION
## 概要

/news ページを作成する

## 関連 Issue

 - Close #36 

## スクリーンショット

| iPhone 14 Pro Max 再現 | Windows 11 Chrome |
| :----: | :----: |
|     <img width="760" height="1649" alt="image" src="https://github.com/user-attachments/assets/dc0d299f-4377-4e43-a951-d05a07bc81d4" />   |     <img width="2414" height="1445" alt="image" src="https://github.com/user-attachments/assets/297cab32-67e9-4df0-9edc-d232d8d54ee4" /> |

## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 新しいニュースページを追加しました。
  * ニュース表示コンポーネントで説明文を任意で表示できるようになりました。
  * 「すべてのニュース」ボタンの表示を切り替えられるようになりました（デフォルトで表示）。
  * ニュース項目に複数バッジを付与できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->