### PR TITLE
ci: use sfw and pin actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -14,4 +14,4 @@ jobs:
     name: Assign PR author as assignee
     runs-on: ubuntu-slim
     steps:
-      - uses: toshimaru/auto-author-assign@v3.0.2
+      - uses: toshimaru/auto-author-assign@bdd7688cbf9e6d5683f02f8c7d8ae4062a254b6d # v3.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,25 +13,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup sfw
+      - name: Set up sfw
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
 
-      - name: Setup pnpm
+      - name: Set up pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         # DO NOT cache pnpm
         # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
-      - name: Setup Node.js Environment
+      - name: Set up Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           # DO NOT cache pnpm
           # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: sfw pnpm install --frozen-lockfile
 
-      - name: Build Check
+      - name: Run build check
         run: pnpm build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,18 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup sfw
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        # DO NOT cache pnpm
+        # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
+          # DO NOT cache pnpm
+          # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
 
       - name: Build Check
         run: pnpm build

--- a/.github/workflows/chromatic-visual.yml
+++ b/.github/workflows/chromatic-visual.yml
@@ -24,24 +24,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup sfw
+      - name: Set up sfw
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
 
-      - name: Setup pnpm
+      - name: Set up pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         # DO NOT cache pnpm
         # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
-      - name: Setup Node.js Environment
+      - name: Set up Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           # DO NOT cache pnpm
           # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: sfw pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium

--- a/.github/workflows/chromatic-visual.yml
+++ b/.github/workflows/chromatic-visual.yml
@@ -20,21 +20,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
+      - name: Setup sfw
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        # DO NOT cache pnpm
+        # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+          # DO NOT cache pnpm
+          # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,18 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup sfw
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        # DO NOT cache pnpm
+        # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
+          # DO NOT cache pnpm
+          # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
 
       - name: Format Check
         run: pnpm fmt:check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,25 +13,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup sfw
+      - name: Set up sfw
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
 
-      - name: Setup pnpm
+      - name: Set up pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         # DO NOT cache pnpm
         # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
-      - name: Setup Node.js Environment
+      - name: Set up Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           # DO NOT cache pnpm
           # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: sfw pnpm install --frozen-lockfile
 
-      - name: Format Check
+      - name: Run format check
         run: pnpm fmt:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,25 +13,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup sfw
+      - name: Set up sfw
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
 
-      - name: Setup pnpm
+      - name: Set up pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         # DO NOT cache pnpm
         # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
-      - name: Setup Node.js Environment
+      - name: Set up Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           # DO NOT cache pnpm
           # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: sfw pnpm install --frozen-lockfile
 
-      - name: Lint Check
+      - name: Run lint check
         run: pnpm lint:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,18 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup sfw
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        # DO NOT cache pnpm
+        # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
+          # DO NOT cache pnpm
+          # `sfw pnpm install` doesn't detect contaminated packages in the cache
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
 
       - name: Lint Check
         run: pnpm lint:check

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Lint PR title
         id: lint_pr_title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -33,7 +33,7 @@ jobs:
 
       - name: Comment on failure
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: semantic-pr-title
           message: |
@@ -69,7 +69,7 @@ jobs:
 
       - name: Clear comment on success
         if: always() && (steps.lint_pr_title.outputs.error_message == null)
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: semantic-pr-title
           delete: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 4320 # 3 days
+minimumReleaseAgeStrict: true
 allowBuilds:
   esbuild: false
   lefthook: true


### PR DESCRIPTION
## 概要

<!-- この PR での変更点などを記載してください -->

- CI での `pnpm i` を [sfw](https://docs.socket.dev/docs/socket-firewall-free) を用いたものに変更
- CI の各 Actions のバージョンをコミットハッシュで指定

## 関連 Issue

<!--
関連する issue があれば記載してください

例: - Close #123
`Close` の前にハイフンとスペースを入れることで issue が見やすくなります
-->

N/A

## 備考

<!--
その他伝えておきたいことがあれば記載してください

- 補足事項
- 注意点
- レビューで特に見てほしい箇所
など
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CIワークフロー内の複数のGitHub Actions参照を特定のコミットSHAに固定し、実行の安定性を向上。
  * 新たに「firewall-free」モードのセットアップステップを追加し、依存インストールを専用ラッパー経由に変更。
  * pnpmキャッシュ方針を明確化し、インストールコマンドおよびコメントを更新。
  * パッケージ設定に最小リリース経過時間（3日）と厳格適用フラグを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/densanken/densanken.com/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->