### PR TITLE
fix: hide signup links after welcome event deadline

### DIFF
--- a/src/pages/_components/CatchCopy.astro
+++ b/src/pages/_components/CatchCopy.astro
@@ -58,13 +58,13 @@ import Button from "../../components/Button.astro";
       >
         <span>活動内容を見る <span aria-hidden="true">&rarr;</span></span>
       </Button>
-      <Button
+      <!-- <Button
         href="/contact#join"
         class="border-2 border-blue-500 bg-white text-blue-500 shadow-blue-500/50 transition-colors focus-visible:ring-blue-500"
       >
-        <!-- <span>入会する <span aria-hidden="true">&rarr;</span></span> -->
         <span>新歓に参加する <span aria-hidden="true">&rarr;</span></span>
       </Button>
+      -->
     </div>
   </section>
 </div>

--- a/src/pages/_components/Join.astro
+++ b/src/pages/_components/Join.astro
@@ -3,11 +3,6 @@ import Button from "../../components/Button.astro";
 ---
 
 <section>
-  <!-- <h2 class="my-2 text-2xl font-bold md:mb-4 md:text-3xl">入会について</h2>
-  <p>以下より入会申請をお願いいたします。</p>
-  <Button href="/contact#join" class="mt-6 bg-indigo-600 text-white shadow-indigo-600/50 focus-visible:ring-indigo-600">
-    <span>入会申請はこちら <span aria-hidden="true">&rarr;</span></span>
-  </Button> -->
   <h2 class="my-2 text-2xl font-bold md:mb-4 md:text-3xl">新歓について</h2>
   <p>新歓に興味のある方には、以下よりフォームの提出をお願いいたします。</p>
   <Button href="/contact#join" class="mt-6 bg-indigo-600 text-white shadow-indigo-600/50 focus-visible:ring-indigo-600">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,7 +3,7 @@ import Button from "../components/Button.astro";
 import Layout from "../layouts/Layout.astro";
 
 const CONTACT_GOOGLE_FORM_URL = import.meta.env.CONTACT_GOOGLE_FORM_URL;
-const JOIN_GOOGLE_FORM_URL = import.meta.env.JOIN_GOOGLE_FORM_URL;
+// const JOIN_GOOGLE_FORM_URL = import.meta.env.JOIN_GOOGLE_FORM_URL;
 ---
 
 <Layout
@@ -23,9 +23,7 @@ const JOIN_GOOGLE_FORM_URL = import.meta.env.JOIN_GOOGLE_FORM_URL;
     <span class="text-xs">（外部リンクに遷移します）</span>
   </Button>
 
-  <!-- <h2 id="join" class="mt-10 mb-2 scroll-mt-20 text-xl font-bold md:text-2xl">入会について</h2>
-  <p>CCSへの入会申請につきましては、こちらのボタンよりお願いいたします。</p> -->
-  <h2 id="join" class="mt-10 mb-2 scroll-mt-20 text-xl font-bold md:text-2xl">新歓への参加について</h2>
+  <!-- <h2 id="join" class="mt-10 mb-2 scroll-mt-20 text-xl font-bold md:text-2xl">新歓への参加について</h2>
   <p>新歓に興味のある方につきましては、こちらのボタンよりフォームの提出をお願いいたします。</p>
   <p>Googleフォームに遷移します。</p>
   <p>（千葉大学の学生に限ります）</p>
@@ -34,10 +32,10 @@ const JOIN_GOOGLE_FORM_URL = import.meta.env.JOIN_GOOGLE_FORM_URL;
     class="mt-6 flex flex-col items-center bg-indigo-600 text-white shadow-indigo-600/50 focus-visible:ring-indigo-600"
     external
   >
-    <!-- <span>入会申請はこちら <span aria-hidden="true">&rarr;</span></span> -->
     <span>新歓参加はこちら <span aria-hidden="true">&rarr;</span></span>
     <span class="text-xs">（外部リンクに遷移します）</span>
-  </Button>
+  </Button> -->
+
   <!-- <p>CCSへの入会申請はサークルの日（2026年4月6日（月）13:00）以降に受付を開始します。</p>
   <p>（千葉大学の学生に限ります）</p> -->
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import Activities from "./_components/Activities.astro";
 import CatchCopy from "./_components/CatchCopy.astro";
-import Join from "./_components/Join.astro";
+// import Join from "./_components/Join.astro";
 import Location from "./_components/Location.astro";
 // import News from "./_components/News.astro";
 // import NewsContent from "./_components/NewsContent.astro";
@@ -35,6 +35,6 @@ import Layout from "../layouts/Layout.astro";
     </News> -->
     <Activities />
     <Location />
-    <Join />
+    <!-- <Join /> -->
   </div>
 </Layout>


### PR DESCRIPTION
## 概要

<!-- この PR での変更点などを記載してください -->

新歓募集を終了する

## 関連 Issue

<!--
関連する issue があれば記載してください

例: - Close #123
`Close` の前にハイフンとスペースを入れることで issue が見やすくなります
-->

N/A

## スクリーンショット

<!--
見た目の変更がある場合にはスクリーンショットを添付してください

変更がない場合はこのセクションを削除して構いません
-->

| 変更前 | 変更後 |
| :----: | :----: |
|<img width="450" height="187" alt="image" src="https://github.com/user-attachments/assets/5db653f1-9a87-4a34-a3e1-946bc3d11174" />|<img width="483" height="195" alt="image" src="https://github.com/user-attachments/assets/1894e758-566a-4991-b2ec-8ceac4bcb300" />|

| 変更前 | 変更後 |
| :----: | :----: |
|<img width="3380" height="1864" alt="image" src="https://github.com/user-attachments/assets/e6fed5ba-0780-4251-a47b-abdc943169df" />|<img width="3380" height="1864" alt="image" src="https://github.com/user-attachments/assets/4844c7fc-ae9a-4ac0-b47e-0024d6d41298" />|

## 備考

<!--
その他伝えておきたいことがあれば記載してください

- 補足事項
- 注意点
- レビューで特に見てほしい箇所
など
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更内容**
  * サイト内の新歓参加ボタンとGoogleフォームへのリンクが一時的に無効化／非表示になりました。
  * トップページおよび関連ページの該当案内・ボタン表示が取り除かれ、画面上からは遷移できなくなります。表示テキスト自体は保持されていますが、ユーザーには表示されません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->