### PR TITLE
chore(vrt): reduce snapshot count and skip chromatic on renovate devdep PRs

### DIFF
--- a/.github/workflows/chromatic-visual.yml
+++ b/.github/workflows/chromatic-visual.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
 
 jobs:
   chromatic-visual:
@@ -17,7 +23,9 @@ jobs:
     env:
       CHROMATIC_ARCHIVE_LOCATION: ./test-results/chromatic
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-
+    if: >
+      github.event_name == 'push' ||
+      !contains(github.event.pull_request.labels.*.name, 'ci:skip-chromatic')
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>densanken/renovate-config"]
+  "extends": ["github>densanken/renovate-config"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "addLabels": ["ci:skip-chromatic"]
+    }
+  ]
 }

--- a/tests/visual/pages.spec.ts
+++ b/tests/visual/pages.spec.ts
@@ -95,16 +95,16 @@ const visualViewports = [
       isMobile: false,
     },
   },
-  {
-    name: "laptop",
-    label: "Laptop",
-    use: {
-      viewport: { width: 1280, height: 720 },
-      deviceScaleFactor: 1,
-      hasTouch: false,
-      isMobile: false,
-    },
-  },
+  // {
+  //   name: "laptop",
+  //   label: "Laptop",
+  //   use: {
+  //     viewport: { width: 1280, height: 720 },
+  //     deviceScaleFactor: 1,
+  //     hasTouch: false,
+  //     isMobile: false,
+  //   },
+  // },
   {
     name: "fhd",
     label: "FHD",
@@ -115,16 +115,16 @@ const visualViewports = [
       isMobile: false,
     },
   },
-  {
-    name: "wqhd",
-    label: "WQHD",
-    use: {
-      viewport: { width: 2560, height: 1440 },
-      deviceScaleFactor: 1,
-      hasTouch: false,
-      isMobile: false,
-    },
-  },
+  // {
+  //   name: "wqhd",
+  //   label: "WQHD",
+  //   use: {
+  //     viewport: { width: 2560, height: 1440 },
+  //     deviceScaleFactor: 1,
+  //     hasTouch: false,
+  //     isMobile: false,
+  //   },
+  // },
 ] as const;
 
 for (const viewport of visualViewports) {

--- a/tests/visual/paths.ts
+++ b/tests/visual/paths.ts
@@ -2,8 +2,8 @@ export const visualTestPaths = [
   { name: "Home", path: "/" },
   { name: "Activities", path: "/activities" },
   { name: "Works Index", path: "/works" },
-  { name: "Works Page 2", path: "/works/2" },
-  { name: "Works 2021", path: "/works/2021" },
-  { name: "Contact", path: "/contact" },
-  { name: "Privacy", path: "/privacy" },
+  // { name: "Works Page 2", path: "/works/2" },
+  // { name: "Works 2021", path: "/works/2021" },
+  // { name: "Contact", path: "/contact" },
+  // { name: "Privacy", path: "/privacy" },
 ] as const;


### PR DESCRIPTION
## 概要

<!-- この PR での変更点などを記載してください -->

chromatic の無料枠を使い切ってしまっているので次のように変更

- 開発依存では実行しない
- 5画面 x 7ページ → 3画面 x 3ページ にスナップショットの数を削減

## 関連 Issue

<!--
関連する issue があれば記載してください

例: - Close #123
`Close` の前にハイフンとスペースを入れることで issue が見やすくなります
-->

N/A

## 備考

<!--
その他伝えておきたいことがあれば記載してください

- 補足事項
- 注意点
- レビューで特に見てほしい箇所
など
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Visualテストの実行条件を見直し、特定のPR操作時のみ実行されるようになりました。
  * 一部の更新でビジュアルテストを自動的にスキップする設定が追加されました。

* **Tests**
  * Visualスナップショットの対象ビューとページが一部整理されました。
  * これにより、実行対象が絞り込まれ、テスト時間が短縮される場合があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->